### PR TITLE
Fix import issue for python 3.6

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -20,12 +20,14 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
+# Depending on the verion of python running, typing may or may not contain
+# Final.  If importing it from typing doesn't work, we'll import it from
+# typing_extensions (its location for older python versions).
 try:
     from typing import Final, Mapping, Optional, Sequence, Tuple
 except ImportError:
     from typing_extensions import Final
     from typing import Mapping, Optional, Sequence, Tuple
-    
 
 # clang-format sha1s were retrieved at
 #  https://commondatastorage.googleapis.com/chromium-clang-format/

--- a/clang_format.py
+++ b/clang_format.py
@@ -20,7 +20,12 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
-from typing import Final, Mapping, Optional, Sequence, Tuple
+try:
+    from typing import Final, Mapping, Optional, Sequence, Tuple
+except ImportError:
+    from typing_extensions import Final
+    from typing import Mapping, Optional, Sequence, Tuple
+    
 
 # clang-format sha1s were retrieved at
 #  https://commondatastorage.googleapis.com/chromium-clang-format/


### PR DESCRIPTION
Fix dependency issue for python 3.6 users:
```
Traceback (most recent call last):
  File "~/.cache/pre-commit/repo6tcjuqfw/clang_format.py", line 23, in <module>
    from typing import Final, Mapping, Optional, Sequence, Tuple
ImportError: cannot import name 'Final'
```

This worked for me and should not affect people who do not encounter this error.
